### PR TITLE
[YM2612] Fix FTBFS with recent gcc.

### DIFF
--- a/src/ym2612/ym2612.h
+++ b/src/ym2612/ym2612.h
@@ -153,7 +153,7 @@ public:
 	struct ConnectionToOutputSlot
 	{
 		unsigned int nOutputSlots;
-		unsigned int slots[4];
+		int slots[4];
 	};
 	static const struct ConnectionToOutputSlot connectionToOutputSlots[8];
 

--- a/src/ym2612/ym2612wave.cpp
+++ b/src/ym2612/ym2612wave.cpp
@@ -626,7 +626,16 @@ std::cout << KC << "," << slot.KS << "," << (KC>>(3-slot.KS)) << ", ";
 
 	if(AR<4)
 	{
-		goto NOTONE;
+//NOTONE:
+		env[0]=0;
+		env[1]=0;
+		env[2]=0;
+		env[3]=0;
+		env[4]=0;
+		env[5]=0;
+		RR=0;
+		return false;
+//		goto NOTONE;
 	}
 
 	auto TLdB100=TLtoDB100[slot.TL];
@@ -634,7 +643,16 @@ std::cout << KC << "," << slot.KS << "," << (KC>>(3-slot.KS)) << ", ";
 
 	if(9600<=TLdB100)
 	{
-		goto NOTONE;
+//NOTONE:
+		env[0]=0;
+		env[1]=0;
+		env[2]=0;
+		env[3]=0;
+		env[4]=0;
+		env[5]=0;
+		RR=0;
+		return false;
+//		goto NOTONE;
 	}
 
 	const unsigned int TLinv=9600-TLdB100;


### PR DESCRIPTION
These changes temporally solution for "narrowing value to unsigned int" FTBFS and cross-jump for goto.

- GCC (and maybe CLANG) checks minus RVALUE for unsigned VAR type.
- GCC (and maybe CLANG) don't allow jump over declaring  variables (without {}).

After changing them, available to build, and maybe works with Debian GNU/Linux (AMD64/Sid).

Regards,
Ohta