### PR TITLE
Support SCSI VERIFY(10) command (partial)

### DIFF
--- a/src/towns/scsi/scsi.h
+++ b/src/towns/scsi/scsi.h
@@ -77,6 +77,7 @@ public:
 		SCSICMD_READ_CAPACITY   =0x25,  // [9] 9.2.7 READ CAPACITY command
 		SCSICMD_READ_10         =0x28,  // [9] 9.2.6 READ(10) command
 		SCSICMD_WRITE_10        =0x2A,  // [9] 9.2.21 WRITE(10) command
+		SCSICMD_VERIFY_10       =0x2F,  // [9] 9.2.19 VERIFY command
 		// When adding a support for command, don't forget to add commandLength[]= in the constructor.
 	};
 


### PR DESCRIPTION
Use of FORMAT.COM on DOS6 for HDD causes error:
> SCSI Command Length not set for this command.

Partial (bytChk=0 only) support of VERIFY(10) command for workaround.