### PR TITLE
fix CMOSSAVE

### DIFF
--- a/src/main_cui/command/townscommand.cpp
+++ b/src/main_cui/command/townscommand.cpp
@@ -2359,7 +2359,7 @@ void TownsCommandInterpreter::Execute_CMOSSave(FMTowns &towns,Command &cmd)
 {
 	if(2<=cmd.argv.size())
 	{
-		if(true!=cpputil::WriteBinaryFile(cmd.argv[1],TOWNS_CMOS_SIZE,TOWNS_CMOS_SIZE,towns.physMem.state.CMOSRAM))
+		if(true!=cpputil::WriteBinaryFile(cmd.argv[1],TOWNS_CMOS_SIZE,towns.physMem.state.CMOSRAM))
 		{
 			PrintError(ERROR_CANNOT_SAVE_FILE);
 		}


### PR DESCRIPTION
`CMOSSAVE` command does not replace output file contents properly.

Fixes:
- Write offset is now zero

Changes:
- Can save to new file
- Output file is truncated to 8KB
