### PR TITLE
Fix out of bounds access

### DIFF
--- a/src/discimg/discimg.cpp
+++ b/src/discimg/discimg.cpp
@@ -45,19 +45,14 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 ////////////////////////////////////////////////////////////
 
-
 static std::string GetExtension(const std::string &fName)
 {
-	for(auto i=fName.size()-1; 0<=i; --i)
-	{
-		if(fName[i]=='.')
-		{
-			std::string ext;
-			ext.insert(ext.end(),fName.begin()+i,fName.end());
-			return ext;
-		}
+	auto pos = fName.rfind('.');
+	if (pos == std::string::npos) {
+		return "";
 	}
-	return "";
+
+	return fName.substr(pos);
 }
 static void Capitalize(std::string &str)
 {

--- a/src/main_cui/command/townscommand.cpp
+++ b/src/main_cui/command/townscommand.cpp
@@ -924,7 +924,10 @@ void TownsCommandInterpreter::Execute(TownsThread &thr,FMTowns &towns,class Outs
 		Execute_TypeKeyboard(towns,cmd);
 		break;
 	case CMD_KEYBOARD:
-		if(nullptr!=outside_world)
+		if (cmd.argv.size() < 2) {
+			PrintError(ERROR_TOO_FEW_ARGS);
+		}
+		else if(nullptr!=outside_world)
 		{
 			std::string MODE=cmd.argv[1];
 			cpputil::Capitalize(MODE);


### PR DESCRIPTION
fix out of bounds access on some mistyped commands
- 'KEYBOARD' (without parameter)
- 'CDLOAD no-such-file'
  - `fName.size()` is unsigned type and `0<=i` is always true