### PR TITLE
fix INTO instruction

### DIFF
--- a/src/cpu/i486.h
+++ b/src/cpu/i486.h
@@ -1880,8 +1880,8 @@ public:
 
 		numInstbyte should tell how many bytes that EIP should be displaced for the return address.
 		For hardware-interrupt, it should be 1.
-		For INT, INTO it should be 2.
-		For INT3, it should be 1.
+		For INT, it should be 2.
+		For INT3 and INTO, it should be 1.
 		For interrupt by exception, it should be 0 to allow re-try.
 
 		numInstBytes is divided into numInstBytesFoReturn and numInstBytesForCallStack.

--- a/src/cpu/i486inst.cpp
+++ b/src/cpu/i486inst.cpp
@@ -1284,8 +1284,9 @@ void i486DX::FetchOperand(CPUCLASS &cpu,Instruction &inst,Operand &op1,Operand &
 	case I486_RENUMBER_INT3://       0xCC,
 		break;
 	case I486_RENUMBER_INT://        0xCD,
+		FUNCCLASS::FetchImm8(cpu, inst, ptr, seg, offset, mem);
+		break;
 	case I486_RENUMBER_INTO://       0xCE,
-		FUNCCLASS::FetchImm8(cpu,inst,ptr,seg,offset,mem);
 		break;
 
 
@@ -2606,9 +2607,8 @@ std::string i486DX::Instruction::Disassemble(const Operand &op1In,const Operand 
 	case I486_OPCODE_INT3://       0xCC,
 		disasm="INT3";
 		break;
-	case I486_OPCODE_INTO://        0xCD,
 	case I486_OPCODE_INT://        0xCD,
-		disasm=(I486_OPCODE_INT==opCode ? "INT" : "INTO");
+		disasm = "INT";
 		disasm=DisassembleTypicalOneImm(disasm,EvalUimm8(),8);
 		if(I486_OPCODE_INT==opCode)
 		{
@@ -2621,6 +2621,9 @@ std::string i486DX::Instruction::Disassemble(const Operand &op1In,const Operand 
 				disasm.push_back(')');
 			}
 		}
+		break;
+	case I486_OPCODE_INTO://        0xCE,
+		disasm = "INTO";
 		break;
 
 
@@ -6130,7 +6133,7 @@ unsigned int i486DX::RunOneInstruction(Memory &mem,InOut &io)
 	case I486_RENUMBER_INTO://       0xCE,
 		if(GetOF())
 		{
-			Interrupt(inst.EvalUimm8(),mem,2,2);
+			Interrupt(INT_INTO_OVERFLOW, mem, 1, 1);
 			EIPIncrement=0;
 			clocksPassed=(IsInRealMode() ? 28 : 46);
 		}


### PR DESCRIPTION
Fix `INTO` instruction decode for SPHR006X.EXE ( \MS_DOS\TOOL\SPHR006X in Free Software Collection 11)