### PR TITLE
Optimize render of each color bits, and CPU Instruction.

### DIFF
--- a/src/cpu/i486inst.cpp
+++ b/src/cpu/i486inst.cpp
@@ -25,8 +25,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 // #define BREAK_ON_FPU_INST
 
 
-/*static*/ int i486DX::opCodeRenumberTable[I486_OPCODE_MAX+1];
-/*static*/ int i486DX::opCodeNeedOperandTable[I486_OPCODE_MAX+1];
+/*static*/ unsigned short i486DX::opCodeRenumberTable[I486_OPCODE_MAX+1];
+/*static*/ unsigned char i486DX::opCodeNeedOperandTable[I486_OPCODE_MAX+1];
 
 void i486DX::MakeOpCodeRenumberTable(void)
 {
@@ -930,7 +930,7 @@ inline unsigned int i486DX::FetchOperandRMandDecode(
 
 	if(16==addressSize)
 	{
-		static const int caseTable[256]=
+		static const unsigned char caseTable[256]=
 		{
 			3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,
 			3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,
@@ -1042,7 +1042,7 @@ inline unsigned int i486DX::FetchOperandRMandDecode(
 		#define G 6
 		#define H 7
 
-		static const int caseTable[256]=
+		static const unsigned char caseTable[256]=
 		{
 			E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,
 			E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,

--- a/src/cpu/i486inst.cpp
+++ b/src/cpu/i486inst.cpp
@@ -25,8 +25,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 // #define BREAK_ON_FPU_INST
 
 
-/*static*/ unsigned short i486DX::opCodeRenumberTable[I486_OPCODE_MAX+1];
-/*static*/ unsigned char i486DX::opCodeNeedOperandTable[I486_OPCODE_MAX+1];
+/*static*/ int i486DX::opCodeRenumberTable[I486_OPCODE_MAX+1];
+/*static*/ int i486DX::opCodeNeedOperandTable[I486_OPCODE_MAX+1];
 
 void i486DX::MakeOpCodeRenumberTable(void)
 {
@@ -930,7 +930,7 @@ inline unsigned int i486DX::FetchOperandRMandDecode(
 
 	if(16==addressSize)
 	{
-		static const unsigned char caseTable[256]=
+		static const int caseTable[256]=
 		{
 			3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,
 			3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,3,3,3,3,3,3,0,3,
@@ -1042,7 +1042,7 @@ inline unsigned int i486DX::FetchOperandRMandDecode(
 		#define G 6
 		#define H 7
 
-		static const unsigned char caseTable[256]=
+		static const int caseTable[256]=
 		{
 			E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,
 			E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,E,E,E,E,B,A,E,E,
@@ -1066,154 +1066,154 @@ inline unsigned int i486DX::FetchOperandRMandDecode(
 			REG_EDI,
 		};
 
-		switch(caseTable[inst.operand[0]])
+		switch (caseTable[inst.operand[0]])
 		{
 		case A:
-			FUNCCLASS::FetchInstructionFourBytes(inst.operand+1,cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
+			FUNCCLASS::FetchInstructionFourBytes(inst.operand + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
-			op.operandType=OPER_ADDR;
-			op.baseReg=REG_NULL;
-			op.indexReg=REG_NULL;
+			op.operandType = OPER_ADDR;
+			op.baseReg = REG_NULL;
+			op.indexReg = REG_NULL;
 			// indexShift=0; Already cleared in Clear()
-			op.offset=cpputil::GetSignedDword(inst.operand+1);
-			op.offsetBits=32;
-			inst.operandLen=5;
+			op.offset = cpputil::GetSignedDword(inst.operand + 1);
+			op.offsetBits = 32;
+			inst.operandLen = 5;
 			break;
 		case B: // MOD==0
+		{
+			inst.operand[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+
+			op.operandType = OPER_ADDR;
+			// indexShift=0; Already cleared in Clear()
+			op.offset = 0;
+
+			auto SIB = inst.operand[1];
+			auto SS = ((SIB >> 6) & 3);
+			auto INDEX = ((SIB >> 3) & 7);
+			auto BASE = (SIB & 7);
+
+			if (5 != BASE)
 			{
-				inst.operand[1]=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
-
-				op.operandType=OPER_ADDR;
-				// indexShift=0; Already cleared in Clear()
-				op.offset=0;
-
-				auto SIB=inst.operand[1];
-				auto SS=((SIB>>6)&3);
-				auto INDEX=((SIB>>3)&7);
-				auto BASE=(SIB&7);
-
-				if(5!=BASE)
-				{
-					op.baseReg=REG_32BIT_REG_BASE+BASE;
-					inst.operandLen=2;
-				}
-				else
-				{
-					FUNCCLASS::FetchInstructionFourBytes(inst.operand+2,cpu,ptr,inst.codeAddressSize,seg,offset+2,mem);
-
-					op.baseReg=REG_NULL; // 0b00==MOD && 5==BASE  disp32[index]
-					op.offsetBits=32;
-					op.offset=cpputil::GetSignedDword(inst.operand+2);
-					inst.operandLen=6;
-				}
-
-				op.indexReg=SIB_INDEX[INDEX];
-				op.indexShift=SS;
+				op.baseReg = REG_32BIT_REG_BASE + BASE;
+				inst.operandLen = 2;
 			}
-			break;
-		case G: // MOD==1
+			else
 			{
-				FUNCCLASS::FetchInstructionTwoBytes(inst.operand+1,cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
+				FUNCCLASS::FetchInstructionFourBytes(inst.operand + 2, cpu, ptr, inst.codeAddressSize, seg, offset + 2, mem);
 
-				op.operandType=OPER_ADDR;
-				// indexShift=0; Already cleared in Clear()
-				op.offset=0;
-
-				auto SIB=inst.operand[1];
-				auto SS=((SIB>>6)&3);
-				auto INDEX=((SIB>>3)&7);
-				auto BASE=(SIB&7);
-
-				if(5!=BASE)
-				{
-					op.baseReg=REG_32BIT_REG_BASE+BASE;
-				}
-				else
-				{
-					op.baseReg=REG_EBP;
-				}
-
-				op.indexReg=SIB_INDEX[INDEX];
-				op.indexShift=SS;
-
-				op.offsetBits=8;
-				op.offset=cpputil::GetSignedByte(inst.operand[2]);
-
-				inst.operandLen=3;
+				op.baseReg = REG_NULL; // 0b00==MOD && 5==BASE  disp32[index]
+				op.offsetBits = 32;
+				op.offset = cpputil::GetSignedDword(inst.operand + 2);
+				inst.operandLen = 6;
 			}
-			break;
-		case H: // MOD==2
-			{
-				inst.operand[1]=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
-				FUNCCLASS::FetchInstructionFourBytes(inst.operand+2,cpu,ptr,inst.codeAddressSize,seg,offset+2,mem);
 
-				op.operandType=OPER_ADDR;
-				// indexShift=0; Already cleared in Clear()
-				op.offset=0;
-
-				auto SIB=inst.operand[1];
-				auto SS=((SIB>>6)&3);
-				auto INDEX=((SIB>>3)&7);
-				auto BASE=(SIB&7);
-
-				if(5!=BASE)
-				{
-					op.baseReg=REG_32BIT_REG_BASE+BASE;
-				}
-				else
-				{
-					op.baseReg=REG_EBP; // 0b10==MOD   disp[EBP][index]
-				}
-
-				op.indexReg=SIB_INDEX[INDEX];
-				op.indexShift=SS;
-
-				op.offsetBits=32;
-				op.offset=cpputil::GetSignedDword(inst.operand+2);
-
-				inst.operandLen=6;
-			}
-			break;
+			op.indexReg = SIB_INDEX[INDEX];
+			op.indexShift = SS;
+		}
+		break;
 		case C:
-			inst.operand[1]=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
+			inst.operand[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
-			op.operandType=OPER_ADDR;
+			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
 
-			op.baseReg=REG_32BIT_REG_BASE+R_M;
-			op.indexReg=REG_NULL;
+			op.baseReg = REG_32BIT_REG_BASE + R_M;
+			op.indexReg = REG_NULL;
 
-			op.offsetBits=8;
-			op.offset=cpputil::GetSignedByte(inst.operand[1]);
-			inst.operandLen=2;
+			op.offsetBits = 8;
+			op.offset = cpputil::GetSignedByte(inst.operand[1]);
+			inst.operandLen = 2;
 			break;
 		case D:
-			FUNCCLASS::FetchInstructionFourBytes(inst.operand+1,cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
+			FUNCCLASS::FetchInstructionFourBytes(inst.operand + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
-			op.operandType=OPER_ADDR;
+			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
 
-			op.baseReg=REG_32BIT_REG_BASE+R_M;
-			op.indexReg=REG_NULL;
+			op.baseReg = REG_32BIT_REG_BASE + R_M;
+			op.indexReg = REG_NULL;
 
-			op.offsetBits=32;
-			op.offset=cpputil::GetSignedDword(inst.operand+1);
-			inst.operandLen=5;
+			op.offsetBits = 32;
+			op.offset = cpputil::GetSignedDword(inst.operand + 1);
+			inst.operandLen = 5;
 			break;
 		case E:
-			op.operandType=OPER_ADDR;
+			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
-			op.offset=0;
-			inst.operandLen=1;
+			op.offset = 0;
+			inst.operandLen = 1;
 
-			op.baseReg=REG_32BIT_REG_BASE+R_M;
-			op.indexReg=REG_NULL;
+			op.baseReg = REG_32BIT_REG_BASE + R_M;
+			op.indexReg = REG_NULL;
 			break;
 		case F:
-			op.operandType=numBytesToRegisterOperandType[dataSize>>3];
-			op.reg=R_M+(numBytesToBasicRegBase[dataSize>>3]);
-			inst.operandLen=1;
+			op.operandType = numBytesToRegisterOperandType[dataSize >> 3];
+			op.reg = R_M + (numBytesToBasicRegBase[dataSize >> 3]);
+			inst.operandLen = 1;
 			break;
+		case G: // MOD==1
+		{
+			FUNCCLASS::FetchInstructionTwoBytes(inst.operand + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+
+			op.operandType = OPER_ADDR;
+			// indexShift=0; Already cleared in Clear()
+			op.offset = 0;
+
+			auto SIB = inst.operand[1];
+			auto SS = ((SIB >> 6) & 3);
+			auto INDEX = ((SIB >> 3) & 7);
+			auto BASE = (SIB & 7);
+
+			if (5 != BASE)
+			{
+				op.baseReg = REG_32BIT_REG_BASE + BASE;
+			}
+			else
+			{
+				op.baseReg = REG_EBP;
+			}
+
+			op.indexReg = SIB_INDEX[INDEX];
+			op.indexShift = SS;
+
+			op.offsetBits = 8;
+			op.offset = cpputil::GetSignedByte(inst.operand[2]);
+
+			inst.operandLen = 3;
+		}
+		break;
+		case H: // MOD==2
+		{
+			inst.operand[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+			FUNCCLASS::FetchInstructionFourBytes(inst.operand + 2, cpu, ptr, inst.codeAddressSize, seg, offset + 2, mem);
+
+			op.operandType = OPER_ADDR;
+			// indexShift=0; Already cleared in Clear()
+			op.offset = 0;
+
+			auto SIB = inst.operand[1];
+			auto SS = ((SIB >> 6) & 3);
+			auto INDEX = ((SIB >> 3) & 7);
+			auto BASE = (SIB & 7);
+
+			if (5 != BASE)
+			{
+				op.baseReg = REG_32BIT_REG_BASE + BASE;
+			}
+			else
+			{
+				op.baseReg = REG_EBP; // 0b10==MOD   disp[EBP][index]
+			}
+
+			op.indexReg = SIB_INDEX[INDEX];
+			op.indexShift = SS;
+
+			op.offsetBits = 32;
+			op.offset = cpputil::GetSignedDword(inst.operand + 2);
+
+			inst.operandLen = 6;
+		}
+		break;
 		}
 	}
 
@@ -1268,379 +1268,372 @@ void i486DX::FetchOperand(CPUCLASS &cpu,InstructionAndOperand &instOp,MemoryAcce
 	auto &op1=instOp.op1;
 	auto &op2=instOp.op2;
 
+	bool refetch;
 
-REFETCH:
-	switch(opCodeNeedOperandTable[inst.opCode])
+	do
 	{
-	// No Operand
-	case I486_NEEDOPERAND_NONE:
-		break;
+		refetch = false;
 
-
-	// Handling multi-byte instruction and pre-fixes >>
-	// This instruction (0x0F) needs the second byte.
-	// Fetch it, and then re-fetch operand.
-	case I486_NEEDOPERAND_NEED_SECOND_BYTE: //0x0F
-		inst.opCode=(I486_OPCODE_NEED_SECOND_BYTE<<8)|FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	// The following cases are not really operand type, but handling these here saves a prefix-fetch loop.
-	case I486_NEEDOPERAND_PREFIX_REP: // REP/REPE/REPZ
-		inst.instPrefix=INST_PREFIX_REP;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_PREFIX_REPNE:
-		inst.instPrefix=INST_PREFIX_REPNE;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_PREFIX_LOCK:
-		inst.instPrefix=INST_PREFIX_LOCK;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_SEG_OVERRIDE_CS:
-		inst.segOverride=SEG_OVERRIDE_CS;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_SEG_OVERRIDE_SS:
-		inst.segOverride=SEG_OVERRIDE_SS;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_SEG_OVERRIDE_DS:
-		inst.segOverride=SEG_OVERRIDE_DS;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_SEG_OVERRIDE_ES:
-		inst.segOverride=SEG_OVERRIDE_ES;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_SEG_OVERRIDE_FS:
-		inst.segOverride=SEG_OVERRIDE_FS;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_SEG_OVERRIDE_GS:
-		inst.segOverride=SEG_OVERRIDE_GS;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_OPERSIZE_OVERRIDE:
-		inst.operandSize=defOperSize^48;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_ADDRSIZE_OVERRIDE:
-		inst.addressSize=defAddrSize^48;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	case I486_NEEDOPERAND_FPU_FWAIT:
-		inst.fwait=FPU_FWAIT;
-		inst.opCode=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset++,mem);
-		++inst.numBytes;
-		goto REFETCH;
-	// Handling multi-byte instruction and pre-fixes <<
-
-
-
-	// RM_IMM8
-	case I486_NEEDOPERAND_RM_IMM8:
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,8,cpu,inst,ptr,seg,offset,mem);
-		FUNCCLASS::FetchImm8(cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-
-	// RM_IMM
-	case I486_NEEDOPERAND_RM_IMM:
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		FUNCCLASS::FetchImm8(cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-
-	// RM8
-	case I486_NEEDOPERAND_RM8:
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,8,cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-
-	// RM_X
-	case I486_NEEDOPERAND_RM_X:
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		break;
-	// RM_R(Will be integrated with RM_X)
-	case I486_NEEDOPERAND_BT_R_RM://    0x0FA3,
-	case I486_NEEDOPERAND_BTC_RM_R://   0x0FBB,
-	case I486_NEEDOPERAND_BTS_RM_R://   0x0FAB,
-	case I486_NEEDOPERAND_BTR_RM_R://   0x0FB3,
-	case I486_NEEDOPERAND_SHLD_RM_CL://       0x0FA5,
-	case I486_NEEDOPERAND_SHRD_RM_CL://       0x0FAD,
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		op2.DecodeMODR_MForRegister(inst.operandSize,inst.operand[0]);
-		break;
-
-
-
-
-	// IMM8
-	case I486_NEEDOPERAND_IMM8:
-		FUNCCLASS::FetchImm8(cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-	// IMM
-	case I486_NEEDOPERAND_IMM:
-		FUNCCLASS::FetchImm16or32(cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-
-	// X_RM
-	case I486_NEEDOPERAND_X_RM:
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		break;
-	// R_RM(WIll be integrated with X_RM)
-	case I486_NEEDOPERAND_BSF_R_RM://   0x0FBC,
-	case I486_NEEDOPERAND_BSR_R_RM://   0x0FBD,
-	case I486_NEEDOPERAND_LAR:
-	case I486_NEEDOPERAND_IMUL_R_RM://       0x0FAF,
-	case I486_NEEDOPERAND_LEA://=              0x8D,
-	case I486_NEEDOPERAND_LSL://              0x0F03,
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeMODR_MForRegister(inst.operandSize,inst.operand[0]);
-		break;
-
-
-
-	// X_RM8
-	case I486_NEEDOPERAND_X_RM8:
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,8,cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-
-	// Yes Operand
-	case I486_NEEDOPERAND_F6_TEST_NOT_NEG_MUL_IMUL_DIV_IDIV: //=0xF6
-		inst.operandSize=8;
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		if(0==inst.GetREG()) // TEST RM8,I8
+		switch (opCodeNeedOperandTable[inst.opCode])
 		{
-			FUNCCLASS::FetchImm8(cpu,inst,ptr,seg,offset,mem);
-		}
-		break;
-	case I486_NEEDOPERAND_F7_TEST_NOT_NEG_MUL_IMUL_DIV_IDIV: //=0xF7,
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		if(0==inst.GetREG()) // TEST RM8,I8
-		{
-			FUNCCLASS::FetchImm16or32(cpu,inst,ptr,seg,offset,mem);
-		}
-		break;
+			// No Operand
+		case I486_NEEDOPERAND_NONE:
+			break;
 
 
 
-	case I486_NEEDOPERAND_ARPL://       0x63,
-		inst.operandSize=16;
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		op2.DecodeMODR_MForRegister(inst.operandSize,inst.operand[0]);
-		break;
+			// RM_IMM8
+		case I486_NEEDOPERAND_RM_IMM8:
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, 8, cpu, inst, ptr, seg, offset, mem);
+			FUNCCLASS::FetchImm8(cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+			// RM_IMM
+		case I486_NEEDOPERAND_RM_IMM:
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			FUNCCLASS::FetchImm8(cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+			// RM8
+		case I486_NEEDOPERAND_RM8:
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, 8, cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+			// RM_X
+		case I486_NEEDOPERAND_RM_X:
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			break;
+			// RM_R(Will be integrated with RM_X)
+		case I486_NEEDOPERAND_BT_R_RM://    0x0FA3,
+		case I486_NEEDOPERAND_BTC_RM_R://   0x0FBB,
+		case I486_NEEDOPERAND_BTS_RM_R://   0x0FAB,
+		case I486_NEEDOPERAND_BTR_RM_R://   0x0FB3,
+		case I486_NEEDOPERAND_SHLD_RM_CL://       0x0FA5,
+		case I486_NEEDOPERAND_SHRD_RM_CL://       0x0FAD,
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			op2.DecodeMODR_MForRegister(inst.operandSize, inst.operand[0]);
+			break;
+
+
+
+
+			// IMM8
+		case I486_NEEDOPERAND_IMM8:
+			FUNCCLASS::FetchImm8(cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+			// IMM
+		case I486_NEEDOPERAND_IMM:
+			FUNCCLASS::FetchImm16or32(cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+			// R_RM(WIll be integrated with X_RM)
+		case I486_NEEDOPERAND_BSF_R_RM://   0x0FBC,
+		case I486_NEEDOPERAND_BSR_R_RM://   0x0FBD,
+		case I486_NEEDOPERAND_LAR:
+		case I486_NEEDOPERAND_IMUL_R_RM://       0x0FAF,
+		case I486_NEEDOPERAND_LEA://=              0x8D,
+		case I486_NEEDOPERAND_LSL://              0x0F03,
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeMODR_MForRegister(inst.operandSize, inst.operand[0]);
+			break;
+
+
+
+			// X_RM
+		case I486_NEEDOPERAND_X_RM:
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+			// X_RM8
+		case I486_NEEDOPERAND_X_RM8:
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, 8, cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+		case I486_NEEDOPERAND_FARPTR:
+			offset += FUNCCLASS::FetchOperand16or32(cpu, inst, ptr, seg, offset, mem);
+			FUNCCLASS::FetchOperand16(cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeFarAddr(inst.addressSize, inst.operandSize, inst.operand);
+			break;
+
+
+
+		case I486_NEEDOPERAND_BINARYOP_R_FROM_I:
+		case I486_NEEDOPERAND_MOV_I_TO_RM: //      0xC7, // 16/32 depends on OPSIZE_OVERRIDE
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			FUNCCLASS::FetchImm16or32(cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+		case I486_NEEDOPERAND_MOV_M_TO_AL: //      0xA0, // 16/32 depends on ADDRESSSIZE_OVERRIDE
+		case I486_NEEDOPERAND_MOV_M_TO_EAX: //     0xA1, // 16/32 depends on ADDRESSSIZE_OVERRIDE
+		case I486_NEEDOPERAND_MOV_M_FROM_AL: //    0xA2, // 16/32 depends on ADDRESSSIZE_OVERRIDE
+		case I486_NEEDOPERAND_MOV_M_FROM_EAX: //   0xA3, // 16/32 depends on ADDRESSSIZE_OVERRIDE
+			switch (inst.addressSize)
+			{
+			case 16:
+				FUNCCLASS::FetchImm16(cpu, inst, ptr, seg, offset, mem);
+				break;
+			default:
+				FUNCCLASS::FetchImm32(cpu, inst, ptr, seg, offset, mem);
+				break;
+			}
+			break;
+
+
+
+		case I486_NEEDOPERAND_MOVSX_R32_RM16://=   0x0FBF,
+		case I486_NEEDOPERAND_MOVZX_R32_RM16://=   0x0FB7,
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, 16, cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeMODR_MForRegister(32, inst.operand[0]);
+			break;
+
+
+
+		case I486_NEEDOPERAND_RET_I16://          0xC2,
+		case I486_NEEDOPERAND_RETF_I16://         0xCA,
+			FUNCCLASS::FetchImm16(cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+		case I486_NEEDOPERAND_SHLD_RM_I8://       0x0FA4,
+		case I486_NEEDOPERAND_SHRD_RM_I8://       0x0FAC,
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			FUNCCLASS::FetchImm8(cpu, inst, ptr, seg, offset, mem);
+			op2.DecodeMODR_MForRegister(inst.operandSize, inst.operand[0]);
+			break;
+
+
+
+		case I486_NEEDOPERAND_SETX:
+			inst.operandSize = 8;
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			break;
+
+
+
+			// Yes Operand
+		case I486_NEEDOPERAND_F6_TEST_NOT_NEG_MUL_IMUL_DIV_IDIV: //=0xF6
+			inst.operandSize = 8;
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			if (0 == inst.GetREG()) // TEST RM8,I8
+			{
+				FUNCCLASS::FetchImm8(cpu, inst, ptr, seg, offset, mem);
+			}
+			break;
+		case I486_NEEDOPERAND_F7_TEST_NOT_NEG_MUL_IMUL_DIV_IDIV: //=0xF7,
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			if (0 == inst.GetREG()) // TEST RM8,I8
+			{
+				FUNCCLASS::FetchImm16or32(cpu, inst, ptr, seg, offset, mem);
+			}
+			break;
+
+
+
+		case I486_NEEDOPERAND_ARPL://       0x63,
+			inst.operandSize = 16;
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			op2.DecodeMODR_MForRegister(inst.operandSize, inst.operand[0]);
+			break;
 
 
 
 
 
-	case I486_NEEDOPERAND_FARPTR:
-		offset+=FUNCCLASS::FetchOperand16or32(cpu,inst,ptr,seg,offset,mem);
-		FUNCCLASS::FetchOperand16(cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeFarAddr(inst.addressSize,inst.operandSize,inst.operand);
-		break;
+
+		case I486_NEEDOPERAND_ENTER://      0xC8,
+			FUNCCLASS::FetchOperand16(cpu, inst, ptr, seg, offset, mem);
+			offset += 2;
+			FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
+			break;
 
 
-
-	case I486_NEEDOPERAND_ENTER://      0xC8,
-		FUNCCLASS::FetchOperand16(cpu,inst,ptr,seg,offset,mem);
-		offset+=2;
-		FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-	case I486_NEEDOPERAND_FPU_D8: // 0xD8
+		case I486_NEEDOPERAND_FPU_D8: // 0xD8
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if(0xC0<=MODR_M && MODR_M<=0xE7) // FADD ST,STi  FMUL ST,STI, FCOM, FCOMP, FSUB
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if (0xC0 <= MODR_M && MODR_M <= 0xE7) // FADD ST,STi  FMUL ST,STI, FCOM, FCOMP, FSUB
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 			}
 			else
 			{
-				FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
+				FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 			}
 		}
 		break;
-	case I486_NEEDOPERAND_FPU_D9:// 0xD9,
+		case I486_NEEDOPERAND_FPU_D9:// 0xD9,
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if((0xC0<=MODR_M && MODR_M<=0xCF) || // FLD_ST, FXCHG
-			   0xE0==MODR_M || // FCHS
-			   0xE1==MODR_M || // FABS
-			   0xE4==MODR_M || // FTST
-			   0xE5==MODR_M || // FXAM
-			   (0xE8<=MODR_M && MODR_M<=0xEE) ||
-			   (0xF0<=MODR_M && MODR_M<=0xFF))
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if ((0xC0 <= MODR_M && MODR_M <= 0xCF) || // FLD_ST, FXCHG
+				0xE0 == MODR_M || // FCHS
+				0xE1 == MODR_M || // FABS
+				0xE4 == MODR_M || // FTST
+				0xE5 == MODR_M || // FXAM
+				(0xE8 <= MODR_M && MODR_M <= 0xEE) ||
+				(0xF0 <= MODR_M && MODR_M <= 0xFF))
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 			}
 			else
 			{
-				FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
+				FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 			}
 		}
 		break;
-	case I486_NEEDOPERAND_FPU_DA:
+		case I486_NEEDOPERAND_FPU_DA:
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if(0xE9==MODR_M) // FUCOMPP
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if (0xE9 == MODR_M) // FUCOMPP
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 			}
 			else
 			{
-				FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
+				FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 			}
 		}
 		break;
-	case I486_NEEDOPERAND_FPU_DB://     0xDB, 
+		case I486_NEEDOPERAND_FPU_DB://     0xDB, 
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if(0xE3==MODR_M || // FNINIT
-			   0xE2==MODR_M)   // FCLEX
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if (0xE3 == MODR_M || // FNINIT
+				0xE2 == MODR_M)   // FCLEX
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 			}
 			else
 			{
-				switch(Instruction::GetREG(MODR_M))
+				switch (Instruction::GetREG(MODR_M))
 				{
 				case 0: // FILD m32int
 				case 3: // FISTP m32int
 				case 5: // FLD m80real
 				case 7: // FSTP m80real
-					FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
+					FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 					break;
 				case 1:
 				case 2:
 				case 4:
 				case 6:
 				default:
-					FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+					FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 					break;
 				}
 			}
 		}
 		break;
-	case I486_NEEDOPERAND_FPU_DC:
+		case I486_NEEDOPERAND_FPU_DC:
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if((0xE8<=MODR_M && MODR_M<=0xEF) || // FSUB ST(i),ST
-			   (0xC0<=MODR_M && MODR_M<=0xC7)    // FADD ST(i),ST
-			   )
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if ((0xE8 <= MODR_M && MODR_M <= 0xEF) || // FSUB ST(i),ST
+				(0xC0 <= MODR_M && MODR_M <= 0xC7)    // FADD ST(i),ST
+				)
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 			}
 			else
 			{
-				FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
+				FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 			}
 		}
 		break;
-	case I486_NEEDOPERAND_FPU_DD:
+		case I486_NEEDOPERAND_FPU_DD:
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if(0xD0==(MODR_M&0xF8)) // D0 11010xxx    [1] pp.151  0<=i<=7
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if (0xD0 == (MODR_M & 0xF8)) // D0 11010xxx    [1] pp.151  0<=i<=7
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);   // FST
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);   // FST
 			}
-			else if(0xD8==(MODR_M&0xF8)) // D8 11011xxx
+			else if (0xD8 == (MODR_M & 0xF8)) // D8 11011xxx
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);   // FSTP
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);   // FSTP
 			}
-			else if(0xC0==(MODR_M&0xF8)) // C0 11000xxx
+			else if (0xC0 == (MODR_M & 0xF8)) // C0 11000xxx
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);   // FFREE
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);   // FFREE
 			}
-			else if(0xE0==(MODR_M&0xF8) || 0xE1==(MODR_M&0xF8) || 0xE8==(MODR_M&0xF8) || 0xE9==(MODR_M&0xF8))
+			else if (0xE0 == (MODR_M & 0xF8) || 0xE1 == (MODR_M & 0xF8) || 0xE8 == (MODR_M & 0xF8) || 0xE9 == (MODR_M & 0xF8))
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);   // FUCOM
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);   // FUCOM
 			}
 			else
 			{
-				switch(Instruction::GetREG(MODR_M))
+				switch (Instruction::GetREG(MODR_M))
 				{
 				default:
-					FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+					FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 					break;
-				// case 6: // FSAVE m94/108byte
+					// case 6: // FSAVE m94/108byte
 					break;
 				case 0:	// FLD m64real
 				case 2: // FST m64real
 				case 3: // FSTP m64real
 				case 7: // FNSTSW m2byte
-					FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
+					FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 					break;
 				}
 			}
 		}
 		break;
 
-	case I486_NEEDOPERAND_FPU_DE:
+		case I486_NEEDOPERAND_FPU_DE:
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if((0xC8<=MODR_M && MODR_M<=0xCF) ||
-			   (0xE0<=MODR_M && MODR_M<=0xEF) ||
-			   (0xF0<=MODR_M && MODR_M<=0xFF) ||
-			    0xD9==MODR_M ||
-			   (0xC0<=MODR_M && MODR_M<=0xC7))
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if ((0xC8 <= MODR_M && MODR_M <= 0xCF) ||
+				(0xE0 <= MODR_M && MODR_M <= 0xEF) ||
+				(0xF0 <= MODR_M && MODR_M <= 0xFF) ||
+				0xD9 == MODR_M ||
+				(0xC0 <= MODR_M && MODR_M <= 0xC7))
 			{
 				// 0xC8+i:FMULP
 				// 0xD9:FCOMPP
 				// 0xF0+i:FDIVR
 				// 0xF8+i:FDIVRP
 				// 0xC0 to 0xC7:FADDP
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 			}
 			else
 			{
-				FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
+				FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 			}
 		}
 		break;
 
-	case I486_NEEDOPERAND_FPU_DF://  0xDF,
+		case I486_NEEDOPERAND_FPU_DF://  0xDF,
 		{
 			unsigned int MODR_M;
-			FUNCCLASS::PeekOperand8(cpu,MODR_M,inst,ptr,seg,offset,mem);
-			if(0xE0==MODR_M) // FNSTSW
+			FUNCCLASS::PeekOperand8(cpu, MODR_M, inst, ptr, seg, offset, mem);
+			if (0xE0 == MODR_M) // FNSTSW
 			{
-				FUNCCLASS::FetchOperand8(cpu,inst,ptr,seg,offset,mem);
+				FUNCCLASS::FetchOperand8(cpu, inst, ptr, seg, offset, mem);
 			}
 			else
 			{
-				FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-				switch(Instruction::GetREG(MODR_M))
+				FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+				switch (Instruction::GetREG(MODR_M))
 				{
 				case 0:
 				case 1:
@@ -1662,164 +1655,204 @@ REFETCH:
 
 
 
-	case I486_NEEDOPERAND_IMUL_R_RM_I8://0x6B,
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		FUNCCLASS::FetchImm8(cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeMODR_MForRegister(inst.operandSize,inst.operand[0]);
-		break;
-	case I486_NEEDOPERAND_IMUL_R_RM_IMM://0x69,
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		if(16==inst.operandSize)
-		{
-			FUNCCLASS::FetchImm16(cpu,inst,ptr,seg,offset,mem);
-		}
-		else
-		{
-			FUNCCLASS::FetchImm32(cpu,inst,ptr,seg,offset,mem);
-		}
-		op1.DecodeMODR_MForRegister(inst.operandSize,inst.operand[0]);
-		break;
-
-
-
-	case I486_NEEDOPERAND_BINARYOP_R_FROM_I:
-	case I486_NEEDOPERAND_MOV_I_TO_RM: //      0xC7, // 16/32 depends on OPSIZE_OVERRIDE
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		FUNCCLASS::FetchImm16or32(cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-	case I486_NEEDOPERAND_LGDT_LIDT_SGDT_SIDT:
-		{
-			auto MODR_M=FUNCCLASS::PeekInstructionByte(cpu,ptr,inst.addressSize,seg,offset,mem);
-			auto REG=inst.GetREG(MODR_M);
-			if(4==REG || 6==REG)
+		case I486_NEEDOPERAND_IMUL_R_RM_I8://0x6B,
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			FUNCCLASS::FetchImm8(cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeMODR_MForRegister(inst.operandSize, inst.operand[0]);
+			break;
+		case I486_NEEDOPERAND_IMUL_R_RM_IMM://0x69,
+			offset += FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			if (16 == inst.operandSize)
 			{
-				inst.operandSize=16;
+				FUNCCLASS::FetchImm16(cpu, inst, ptr, seg, offset, mem);
 			}
-			FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		}
-		break;
+			else
+			{
+				FUNCCLASS::FetchImm32(cpu, inst, ptr, seg, offset, mem);
+			}
+			op1.DecodeMODR_MForRegister(inst.operandSize, inst.operand[0]);
+			break;
 
 
 
-	case I486_NEEDOPERAND_MOV_FROM_SEG: //     0x8C,
-		// Example:  8c c6           MOV SI,ES
-		// Sreg: ES=0, CS=1, SS=2, DS=3, FD=4, GS=5 (OPCODE part of MODR_M)  [1] pp.26-10
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		// From observation on 2020/04/22, if the upper-16 bit of the destination register is undefined
-		// F-BASIC386 booted from CD may fail to open windows.
-		// From observation on 2020/10/24, if the operandSize is 32, upper 32-bit of the destination
-		// register must be clear instead of being preserved.
-		// Therefore, MOV AX,DS and MOV EAX,DS probably should behave differently.
-		// Hence the following clause "Force it to be 16-bit" is reverted and commented out.
-		// inst.operandSize=16; // Force it to be 16-bit
-		op2.DecodeMODR_MForSegmentRegister(inst.operand[0]);
-		break;
-	case I486_NEEDOPERAND_MOV_TO_SEG: //       0x8E,
-		inst.operandSize=16; // Force it to be 16-bit
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeMODR_MForSegmentRegister(inst.operand[0]);
-		break;
 
-	case I486_NEEDOPERAND_MOV_M_TO_AL: //      0xA0, // 16/32 depends on ADDRESSSIZE_OVERRIDE
-	case I486_NEEDOPERAND_MOV_M_TO_EAX: //     0xA1, // 16/32 depends on ADDRESSSIZE_OVERRIDE
-	case I486_NEEDOPERAND_MOV_M_FROM_AL: //    0xA2, // 16/32 depends on ADDRESSSIZE_OVERRIDE
-	case I486_NEEDOPERAND_MOV_M_FROM_EAX: //   0xA3, // 16/32 depends on ADDRESSSIZE_OVERRIDE
-		switch(inst.addressSize)
+		case I486_NEEDOPERAND_LGDT_LIDT_SGDT_SIDT:
 		{
-		default:
-			FUNCCLASS::FetchImm32(cpu,inst,ptr,seg,offset,mem);
-			break;
-		case 16:
-			FUNCCLASS::FetchImm16(cpu,inst,ptr,seg,offset,mem);
-			break;
+			auto MODR_M = FUNCCLASS::PeekInstructionByte(cpu, ptr, inst.addressSize, seg, offset, mem);
+			auto REG = inst.GetREG(MODR_M);
+			if (4 == REG || 6 == REG)
+			{
+				inst.operandSize = 16;
+			}
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
 		}
 		break;
 
 
 
-	case I486_NEEDOPERAND_MOV_TO_CR://        0x0F22,
-		inst.operandSize=32; // [1] pp.26-213 32bit operands are always used with these instructions, 
-		                     //      regardless of the opreand-size attribute.
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,32,cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeMODR_MForCRRegister(inst.operand[0]);
-		break;
-	case I486_NEEDOPERAND_MOV_TO_DR://        0x0F23,
-		inst.operandSize=32; // [1] pp.26-213 32bit operands are always used with these instructions, 
-		                     //      regardless of the opreand-size attribute.
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,32,cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeMODR_MForDRRegister(inst.operand[0]);
-		break;
-	case I486_NEEDOPERAND_MOV_TO_TR://        0x0F26,
-		inst.operandSize=32; // [1] pp.26-213 32bit operands are always used with these instructions, 
-		                     //      regardless of the opreand-size attribute.
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,32,cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeMODR_MForTestRegister(inst.operand[0]);
-		break;
-	case I486_NEEDOPERAND_MOV_FROM_CR://      0x0F20,
-		inst.operandSize=32; // [1] pp.26-213 32bit operands are always used with these instructions, 
-		                     //      regardless of the opreand-size attribute.
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,32,cpu,inst,ptr,seg,offset,mem);
-		op2.DecodeMODR_MForCRRegister(inst.operand[0]);
-		break;
-	case I486_NEEDOPERAND_MOV_FROM_DR://      0x0F21,
-		inst.operandSize=32; // [1] pp.26-213 32bit operands are always used with these instructions, 
-		                     //      regardless of the opreand-size attribute.
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,32,cpu,inst,ptr,seg,offset,mem);
-		op2.DecodeMODR_MForDRRegister(inst.operand[0]);
-		break;
-	case I486_NEEDOPERAND_MOV_FROM_TR://      0x0F24,
-		inst.operandSize=32; // [1] pp.26-213 32bit operands are always used with these instructions, 
-		                     //      regardless of the opreand-size attribute.
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,32,cpu,inst,ptr,seg,offset,mem);
-		op2.DecodeMODR_MForTestRegister(inst.operand[0]);
-		break;
+		case I486_NEEDOPERAND_MOV_FROM_SEG: //     0x8C,
+			// Example:  8c c6           MOV SI,ES
+			// Sreg: ES=0, CS=1, SS=2, DS=3, FD=4, GS=5 (OPCODE part of MODR_M)  [1] pp.26-10
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			// From observation on 2020/04/22, if the upper-16 bit of the destination register is undefined
+			// F-BASIC386 booted from CD may fail to open windows.
+			// From observation on 2020/10/24, if the operandSize is 32, upper 32-bit of the destination
+			// register must be clear instead of being preserved.
+			// Therefore, MOV AX,DS and MOV EAX,DS probably should behave differently.
+			// Hence the following clause "Force it to be 16-bit" is reverted and commented out.
+			// inst.operandSize=16; // Force it to be 16-bit
+			op2.DecodeMODR_MForSegmentRegister(inst.operand[0]);
+			break;
+		case I486_NEEDOPERAND_MOV_TO_SEG: //       0x8E,
+			inst.operandSize = 16; // Force it to be 16-bit
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeMODR_MForSegmentRegister(inst.operand[0]);
+			break;
 
 
 
 
-	case I486_NEEDOPERAND_MOVSX_R32_RM16://=   0x0FBF,
-	case I486_NEEDOPERAND_MOVZX_R32_RM16://=   0x0FB7,
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op2,inst.addressSize,16,cpu,inst,ptr,seg,offset,mem);
-		op1.DecodeMODR_MForRegister(32,inst.operand[0]);
-		break;
+		case I486_NEEDOPERAND_MOV_TO_CR://        0x0F22,
+			inst.operandSize = 32; // [1] pp.26-213 32bit operands are always used with these instructions, 
+			//      regardless of the opreand-size attribute.
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, 32, cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeMODR_MForCRRegister(inst.operand[0]);
+			break;
+		case I486_NEEDOPERAND_MOV_TO_DR://        0x0F23,
+			inst.operandSize = 32; // [1] pp.26-213 32bit operands are always used with these instructions, 
+			//      regardless of the opreand-size attribute.
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, 32, cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeMODR_MForDRRegister(inst.operand[0]);
+			break;
+		case I486_NEEDOPERAND_MOV_TO_TR://        0x0F26,
+			inst.operandSize = 32; // [1] pp.26-213 32bit operands are always used with these instructions, 
+			//      regardless of the opreand-size attribute.
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op2, inst.addressSize, 32, cpu, inst, ptr, seg, offset, mem);
+			op1.DecodeMODR_MForTestRegister(inst.operand[0]);
+			break;
+		case I486_NEEDOPERAND_MOV_FROM_CR://      0x0F20,
+			inst.operandSize = 32; // [1] pp.26-213 32bit operands are always used with these instructions, 
+			//      regardless of the opreand-size attribute.
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, 32, cpu, inst, ptr, seg, offset, mem);
+			op2.DecodeMODR_MForCRRegister(inst.operand[0]);
+			break;
+		case I486_NEEDOPERAND_MOV_FROM_DR://      0x0F21,
+			inst.operandSize = 32; // [1] pp.26-213 32bit operands are always used with these instructions, 
+			//      regardless of the opreand-size attribute.
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, 32, cpu, inst, ptr, seg, offset, mem);
+			op2.DecodeMODR_MForDRRegister(inst.operand[0]);
+			break;
+		case I486_NEEDOPERAND_MOV_FROM_TR://      0x0F24,
+			inst.operandSize = 32; // [1] pp.26-213 32bit operands are always used with these instructions, 
+			//      regardless of the opreand-size attribute.
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, 32, cpu, inst, ptr, seg, offset, mem);
+			op2.DecodeMODR_MForTestRegister(inst.operand[0]);
+			break;
 
 
 
-	case I486_NEEDOPERAND_RET_I16://          0xC2,
-	case I486_NEEDOPERAND_RETF_I16://         0xCA,
-		FUNCCLASS::FetchImm16(cpu,inst,ptr,seg,offset,mem);
-		break;
+		case I486_NEEDOPERAND_SLDT_STR_LLDT_LTR_VERR_VERW://             0x0F00,
+			inst.operandSize = 16;
+			FetchOperandRMandDecode<CPUCLASS, MEMCLASS, FUNCCLASS>(op1, inst.addressSize, inst.operandSize, cpu, inst, ptr, seg, offset, mem);
+			break;
 
 
 
-	case I486_NEEDOPERAND_SHLD_RM_I8://       0x0FA4,
-	case I486_NEEDOPERAND_SHRD_RM_I8://       0x0FAC,
-		offset+=FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		FUNCCLASS::FetchImm8(cpu,inst,ptr,seg,offset,mem);
-		op2.DecodeMODR_MForRegister(inst.operandSize,inst.operand[0]);
-		break;
+			// Handling multi-byte instruction and pre-fixes >>
+	// This instruction (0x0F) needs the second byte.
+	// Fetch it, and then re-fetch operand.
+		case I486_NEEDOPERAND_NEED_SECOND_BYTE: //0x0F
+			inst.opCode = (I486_OPCODE_NEED_SECOND_BYTE << 8) | FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+			// The following cases are not really operand type, but handling these here saves a prefix-fetch loop.
+		case I486_NEEDOPERAND_PREFIX_REP: // REP/REPE/REPZ
+			inst.instPrefix = INST_PREFIX_REP;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_PREFIX_REPNE:
+			inst.instPrefix = INST_PREFIX_REPNE;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_PREFIX_LOCK:
+			inst.instPrefix = INST_PREFIX_LOCK;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_SEG_OVERRIDE_CS:
+			inst.segOverride = SEG_OVERRIDE_CS;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_SEG_OVERRIDE_SS:
+			inst.segOverride = SEG_OVERRIDE_SS;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_SEG_OVERRIDE_DS:
+			inst.segOverride = SEG_OVERRIDE_DS;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_SEG_OVERRIDE_ES:
+			inst.segOverride = SEG_OVERRIDE_ES;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_SEG_OVERRIDE_FS:
+			inst.segOverride = SEG_OVERRIDE_FS;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_SEG_OVERRIDE_GS:
+			inst.segOverride = SEG_OVERRIDE_GS;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_OPERSIZE_OVERRIDE:
+			inst.operandSize = defOperSize ^ 48;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_ADDRSIZE_OVERRIDE:
+			inst.addressSize = defAddrSize ^ 48;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+		case I486_NEEDOPERAND_FPU_FWAIT:
+			inst.fwait = FPU_FWAIT;
+			inst.opCode = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset++, mem);
+			++inst.numBytes;
+			refetch = true;
+			break;
+			// Handling multi-byte instruction and pre-fixes <<
 
 
 
-	case I486_NEEDOPERAND_SETX:
-		inst.operandSize=8;
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		break;
+		default:
+#if defined(_MSC_VER)
+			__assume(0);
+#endif
+			// Undefined operand, or probably not implemented yet.
+			//break;
+		}
 
+	} while (refetch);
 
-	case I486_NEEDOPERAND_SLDT_STR_LLDT_LTR_VERR_VERW://             0x0F00,
-		inst.operandSize=16;
-		FetchOperandRMandDecode<CPUCLASS,MEMCLASS,FUNCCLASS>(op1,inst.addressSize,inst.operandSize,cpu,inst,ptr,seg,offset,mem);
-		break;
-
-
-
-	default:
-		// Undefined operand, or probably not implemented yet.
-		break;
-	}
 }
 
 std::string i486DX::Instruction::Disassemble(const Operand &op1In,const Operand &op2In,SegmentRegister cs,unsigned int eip,const i486SymbolTable &symTable,const std::map <unsigned int,std::string> &ioTable) const
@@ -9321,6 +9354,9 @@ unsigned int i486DX::RunOneInstruction(Memory &mem,InOut &io)
 
 
 	default:
+#if defined(_MSC_VER)
+		__assume(0);
+#endif
 		Abort("Undefined instruction or simply not supported yet.");
 		return 0;
 	}


### PR DESCRIPTION
Remove conditional branchs of (true != transparent) from "for" in "for" in "for" loops in TownsRender::Render of each colors, and  swich instructions compiled with jump table in i486DX::FetchOperand and i486DX::RunOneInstruction. jump table optimize is faster x1.3 then existing.