### PR TITLE
FPU instructions for mirb

### DIFF
--- a/src/cpu/i486.h
+++ b/src/cpu/i486.h
@@ -607,7 +607,9 @@ public:
 		unsigned int FCOMP_m32real(i486DXCommon &cpu,const unsigned char byteData[]);
 		unsigned int FCOM_m64real(i486DXCommon &cpu,const unsigned char byteData[]);
 		unsigned int FCOMP_m64real(i486DXCommon &cpu,const unsigned char byteData[]);
-		unsigned int FUCOM_STi(i486DXCommon &cpu,int i);
+		unsigned int FUCOM_STi(i486DXCommon& cpu, int i);
+		unsigned int FUCOMP_STi(i486DXCommon& cpu, int i);
+		unsigned int FUCOMPP(i486DXCommon& cpu);
 		unsigned int FCOS(i486DXCommon &cpu);
 		unsigned int FIDIV_m16int(i486DXCommon &cpu,const unsigned char byteData[]);
 		unsigned int FILD_m16int(i486DXCommon &cpu,const unsigned char byteData[]);
@@ -656,6 +658,7 @@ public:
 		unsigned int FSUB_ST_STi(i486DXCommon &cpu,int i);
 		unsigned int FSUB_STi_ST(i486DXCommon &cpu,int i);
 		unsigned int FSUBP_STi_ST(i486DXCommon &cpu,int i);
+		unsigned int FISUB_m16int(i486DXCommon& cpu, const unsigned char byteData[]);
 		unsigned int FSUBR_m32real(i486DXCommon &cpu,const unsigned char byteData[]);
 		unsigned int FSUBR_m64real(i486DXCommon &cpu,const unsigned char byteData[]);
 		unsigned int FSUBRP_STi_ST(i486DXCommon &cpu,int i);

--- a/src/cpu/i486inst.cpp
+++ b/src/cpu/i486inst.cpp
@@ -1575,7 +1575,9 @@ std::string i486DXCommon::Instruction::Disassemble(const Operand &op1In,const Op
 			}
 			else if(0xE8==(MODR_M&0xF8))
 			{
-				disasm="?FPUINST";
+				disasm = "FUCOMP ST(";
+				disasm += cpputil::Ubtox(MODR_M & 7);
+				disasm += ")";
 			}
 			else
 			{

--- a/src/cpu/i486inst.cpp
+++ b/src/cpu/i486inst.cpp
@@ -1553,7 +1553,9 @@ std::string i486DXCommon::Instruction::Disassemble(const Operand &op1In,const Op
 			unsigned int MODR_M=operand[0];
 			if(0xD0==(MODR_M&0xF8)) // D0 11010xxx    [1] pp.151  0<=i<=7
 			{
-				disasm="?FPUINST";
+				disasm = "FST ST(";
+				disasm += cpputil::Ubtox(MODR_M & 7);
+				disasm += ")";
 			}
 			else if(0xD8==(MODR_M&0xF8)) // D8 11011xxx
 			{

--- a/src/cpu/i486templatefunctions.h
+++ b/src/cpu/i486templatefunctions.h
@@ -1259,7 +1259,7 @@ i486DXCommon::OperandValue i486DXFidelityLayer<FIDELITY>::EvaluateOperand80(
 	switch(op.operandType)
 	{
 	default:
-		Abort("Tried to evaluate 64-bit from an inappropriate operandType.");
+		Abort("Tried to evaluate 80-bit from an inappropriate operandType.");
 		break;
 	case OPER_ADDR:
 		{

--- a/src/cpu/i487.cpp
+++ b/src/cpu/i487.cpp
@@ -723,12 +723,32 @@ unsigned int i486DXCommon::FPUState::FCOMPP(i486DXCommon &cpu)
 	}
 	return 0; // Let it abort.
 }
-unsigned int i486DXCommon::FPUState::FUCOM_STi(i486DXCommon &cpu,int i)
+unsigned int i486DXCommon::FPUState::FUCOM_STi(i486DXCommon& cpu, int i)
 {
-	if(true==enabled)
+	if (true == enabled)
 	{
-		Compare(ST(cpu).value,ST(cpu,i).value);
+		Compare(ST(cpu).value, ST(cpu, i).value);
 		return 4;
+	}
+	return 0; // Let it abort.
+}
+unsigned int i486DXCommon::FPUState::FUCOMP_STi(i486DXCommon& cpu, int i)
+{
+	if (true == enabled)
+	{
+		Compare(ST(cpu).value, ST(cpu, i).value);
+		Pop(cpu);
+		return 4;
+	}
+	return 0; // Let it abort.
+}
+unsigned int i486DXCommon::FPUState::FUCOMPP(i486DXCommon& cpu)
+{
+	if (true == enabled)
+	{
+		Compare(ST(cpu).value, ST(cpu, 1).value);
+		Pop(cpu, 2);
+		return 5;
 	}
 	return 0; // Let it abort.
 }
@@ -1644,6 +1664,19 @@ unsigned int i486DXCommon::FPUState::FSUBP_STi_ST(i486DXCommon &cpu,int i)
 		STi.value=STi.value-ST.value;
 		Pop(cpu);
 		return 10;
+	}
+	return 0;
+}
+unsigned int i486DXCommon::FPUState::FISUB_m16int(i486DXCommon& cpu, const unsigned char byteData[])
+{
+	if (true == enabled)
+	{
+		statusWord &= ~STATUS_C1;
+
+		double src = (double)IntFrom16Bit(byteData);
+		ST(cpu).value -= src;
+
+		return 24;
 	}
 	return 0;
 }

--- a/src/cpu/i487.cpp
+++ b/src/cpu/i487.cpp
@@ -626,7 +626,7 @@ unsigned int i486DXCommon::FPUState::FIADD_m16int(i486DXCommon &cpu,const unsign
 		double src=(double)IntFrom16Bit(byteData);
 		ST(cpu).value+=src;
 
-		return 7;
+		return 24;
 	}
 	return 0;
 }


### PR DESCRIPTION
implement 80387 instructions needed to execute basic floating point arith on mruby.