### PR TITLE
Optimize and, modify REP clocks and SLOWMODE FREQ.

### DIFF
--- a/gui/src/main_gui/fsguiapp.cpp
+++ b/gui/src/main_gui/fsguiapp.cpp
@@ -279,7 +279,7 @@ void FsGuiMainCanvas::MakeMainMenu(void)
 		{
 			auto *freqSubMenu=subMenu->AddTextItem(0,FSKEY_F,L"CPU Frequency")->AddSubMenu();
 			freqSubMenu->AddTextItem(0,FSKEY_1,L"1MHz")->BindCallBack(&THISCLASS::VM_1MHz,this);
-			freqSubMenu->AddTextItem(0,FSKEY_2,L"4MHz")->BindCallBack(&THISCLASS::VM_4MHz,this);
+			freqSubMenu->AddTextItem(0,FSKEY_2,L"5MHz")->BindCallBack(&THISCLASS::VM_5MHz,this);
 			freqSubMenu->AddTextItem(0,FSKEY_3,L"8MHz")->BindCallBack(&THISCLASS::VM_8MHz,this);
 			freqSubMenu->AddTextItem(0,FSKEY_4,L"12MHz")->BindCallBack(&THISCLASS::VM_12MHz,this);
 			freqSubMenu->AddTextItem(0,FSKEY_5,L"16MHz")->BindCallBack(&THISCLASS::VM_16MHz,this);
@@ -1844,11 +1844,11 @@ void FsGuiMainCanvas::VM_1MHz(FsGuiPopUpMenuItem *)
 		VM_Not_Running_Error();
 	}
 }
-void FsGuiMainCanvas::VM_4MHz(FsGuiPopUpMenuItem *)
+void FsGuiMainCanvas::VM_5MHz(FsGuiPopUpMenuItem *)
 {
 	if(true==IsVMRunning())
 	{
-		SendVMCommand("FREQ 4\n");
+		SendVMCommand("FREQ 5\n");
 		VMMustResume=YSTRUE;
 	}
 	else

--- a/gui/src/main_gui/fsguiapp.h
+++ b/gui/src/main_gui/fsguiapp.h
@@ -267,7 +267,7 @@ private:
 	void VM_Resume(FsGuiPopUpMenuItem *);
 
 	void VM_1MHz(FsGuiPopUpMenuItem *);
-	void VM_4MHz(FsGuiPopUpMenuItem *);
+	void VM_5MHz(FsGuiPopUpMenuItem *);
 	void VM_8MHz(FsGuiPopUpMenuItem *);
 	void VM_12MHz(FsGuiPopUpMenuItem *);
 	void VM_16MHz(FsGuiPopUpMenuItem *);

--- a/src/cpu/i486.cpp
+++ b/src/cpu/i486.cpp
@@ -2131,7 +2131,7 @@ bool i486DXCommon::REPCheck(unsigned int &clocksPassed,unsigned int instPrefix,u
 		}
 		--counter;
 		SetCXorECX(addressSize,counter);
-		clocksPassed+=7;
+		clocksPassed+=3;
 	}
 	return true;
 }

--- a/src/cpu/i486runinstruction.h
+++ b/src/cpu/i486runinstruction.h
@@ -7,12 +7,13 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
     Operand &op,int addressSize,int dataSize,
     CPUCLASS &cpu,Instruction &inst,MemoryAccess::ConstPointer &ptr,const SegmentRegister &seg,unsigned int offset,MEMCLASS &mem)
 {
-	inst.operand[0]=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset,mem);
+	auto *operandPtr=inst.operand;
+	operandPtr[0]=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset,mem);
 
 	NUM_BYTES_TO_BASIC_REG_BASE
 	NUM_BYTES_TO_REGISTER_OPERAND_TYPE
 
-	const auto MODR_M=inst.operand[0];
+	const auto MODR_M=operandPtr[0];
 	const auto MOD=((MODR_M>>6)&3);
 	// const auto REG_OPCODE=((MODR_M>>3)&7);
 	#define R_M (MODR_M&7)
@@ -71,39 +72,39 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			{REG_BX,REG_SI},{REG_BX,REG_DI},{REG_BP,REG_SI},{REG_BP,REG_DI},{REG_SI,REG_NULL},{REG_DI,REG_NULL},{REG_BP,REG_NULL},{REG_BX,REG_NULL},
 		};
 
-		switch(caseTable[inst.operand[0]])
+		switch(caseTable[operandPtr[0]])
 		{
 		case 0:
-			FUNCCLASS::FetchInstructionTwoBytes(inst.operand+1,cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
+			FUNCCLASS::FetchInstructionTwoBytes(operandPtr+1,cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
 
 			op.operandType=OPER_ADDR;
 			op.baseReg=REG_NULL;
 			op.indexReg=REG_NULL;
 			// indexShift=0; Already cleared in Clear()
-			op.offset=cpputil::GetSignedWord(inst.operand+1);
+			op.offset=cpputil::GetSignedWord(operandPtr+1);
 			op.offsetBits=16;
 			inst.operandLen=3;
 			break;
 		case 1:
-			inst.operand[1]=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
+			operandPtr[1]=FUNCCLASS::FetchInstructionByte(cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
 
 			op.operandType=OPER_ADDR;
 			// indexShisft=0; Already cleared in Clear()
 			op.baseReg=MODR_M_to_BaseIndex[MODR_M][0];
 			op.indexReg=MODR_M_to_BaseIndex[MODR_M][1];
 			op.offsetBits=8;
-			op.offset=cpputil::GetSignedByte(inst.operand[1]);
+			op.offset=cpputil::GetSignedByte(operandPtr[1]);
 			inst.operandLen=2;
 			break;
 		case 2:
-			FUNCCLASS::FetchInstructionTwoBytes(inst.operand+1,cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
+			FUNCCLASS::FetchInstructionTwoBytes(operandPtr+1,cpu,ptr,inst.codeAddressSize,seg,offset+1,mem);
 
 			op.operandType=OPER_ADDR;
 			// indexShisft=0; Already cleared in Clear()
 			op.baseReg=MODR_M_to_BaseIndex[MODR_M][0];
 			op.indexReg=MODR_M_to_BaseIndex[MODR_M][1];
 			op.offsetBits=16;
-			op.offset=cpputil::GetSignedWord(inst.operand+1);
+			op.offset=cpputil::GetSignedWord(operandPtr+1);
 			inst.operandLen=3;
 			break;
 		case 3:
@@ -160,28 +161,28 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			REG_EDI,
 		};
 
-		switch (caseTable[inst.operand[0]])
+		switch (caseTable[operandPtr[0]])
 		{
 		case A:
-			FUNCCLASS::FetchInstructionFourBytes(inst.operand + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+			FUNCCLASS::FetchInstructionFourBytes(operandPtr + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
 			op.operandType = OPER_ADDR;
 			op.baseReg = REG_NULL;
 			op.indexReg = REG_NULL;
 			// indexShift=0; Already cleared in Clear()
-			op.offset = cpputil::GetSignedDword(inst.operand + 1);
+			op.offset = cpputil::GetSignedDword(operandPtr + 1);
 			op.offsetBits = 32;
 			inst.operandLen = 5;
 			break;
 		case B: // MOD==0
 		{
-			inst.operand[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+			operandPtr[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
 			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
 			op.offset = 0;
 
-			auto SIB = inst.operand[1];
+			auto SIB = operandPtr[1];
 			auto SS = ((SIB >> 6) & 3);
 			auto INDEX = ((SIB >> 3) & 7);
 			auto BASE = (SIB & 7);
@@ -193,11 +194,11 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			}
 			else
 			{
-				FUNCCLASS::FetchInstructionFourBytes(inst.operand + 2, cpu, ptr, inst.codeAddressSize, seg, offset + 2, mem);
+				FUNCCLASS::FetchInstructionFourBytes(operandPtr + 2, cpu, ptr, inst.codeAddressSize, seg, offset + 2, mem);
 
 				op.baseReg = REG_NULL; // 0b00==MOD && 5==BASE  disp32[index]
 				op.offsetBits = 32;
-				op.offset = cpputil::GetSignedDword(inst.operand + 2);
+				op.offset = cpputil::GetSignedDword(operandPtr + 2);
 				inst.operandLen = 6;
 			}
 
@@ -206,7 +207,7 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 		}
 		break;
 		case C:
-			inst.operand[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+			operandPtr[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
 			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
@@ -215,11 +216,11 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			op.indexReg = REG_NULL;
 
 			op.offsetBits = 8;
-			op.offset = cpputil::GetSignedByte(inst.operand[1]);
+			op.offset = cpputil::GetSignedByte(operandPtr[1]);
 			inst.operandLen = 2;
 			break;
 		case D:
-			FUNCCLASS::FetchInstructionFourBytes(inst.operand + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+			FUNCCLASS::FetchInstructionFourBytes(operandPtr + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
 			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
@@ -228,7 +229,7 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			op.indexReg = REG_NULL;
 
 			op.offsetBits = 32;
-			op.offset = cpputil::GetSignedDword(inst.operand + 1);
+			op.offset = cpputil::GetSignedDword(operandPtr + 1);
 			inst.operandLen = 5;
 			break;
 		case E:
@@ -247,13 +248,13 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			break;
 		case G: // MOD==1
 		{
-			FUNCCLASS::FetchInstructionTwoBytes(inst.operand + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+			FUNCCLASS::FetchInstructionTwoBytes(operandPtr + 1, cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
 
 			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
 			op.offset = 0;
 
-			auto SIB = inst.operand[1];
+			auto SIB = operandPtr[1];
 			auto SS = ((SIB >> 6) & 3);
 			auto INDEX = ((SIB >> 3) & 7);
 			auto BASE = (SIB & 7);
@@ -271,21 +272,21 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			op.indexShift = SS;
 
 			op.offsetBits = 8;
-			op.offset = cpputil::GetSignedByte(inst.operand[2]);
+			op.offset = cpputil::GetSignedByte(operandPtr[2]);
 
 			inst.operandLen = 3;
 		}
 		break;
 		case H: // MOD==2
 		{
-			inst.operand[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
-			FUNCCLASS::FetchInstructionFourBytes(inst.operand + 2, cpu, ptr, inst.codeAddressSize, seg, offset + 2, mem);
+			operandPtr[1] = FUNCCLASS::FetchInstructionByte(cpu, ptr, inst.codeAddressSize, seg, offset + 1, mem);
+			FUNCCLASS::FetchInstructionFourBytes(operandPtr + 2, cpu, ptr, inst.codeAddressSize, seg, offset + 2, mem);
 
 			op.operandType = OPER_ADDR;
 			// indexShift=0; Already cleared in Clear()
 			op.offset = 0;
 
-			auto SIB = inst.operand[1];
+			auto SIB = operandPtr[1];
 			auto SS = ((SIB >> 6) & 3);
 			auto INDEX = ((SIB >> 3) & 7);
 			auto BASE = (SIB & 7);
@@ -303,7 +304,7 @@ inline unsigned int i486DXCommon::FetchOperandRMandDecode(
 			op.indexShift = SS;
 
 			op.offsetBits = 32;
-			op.offset = cpputil::GetSignedDword(inst.operand + 2);
+			op.offset = cpputil::GetSignedDword(operandPtr + 2);
 
 			inst.operandLen = 6;
 		}
@@ -3041,7 +3042,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 				{
 					SubByte(data1,data2);
 					UpdateESIandEDIAfterStringOp(inst.addressSize,8);
-					clocksPassed+=8;
+					clocksPassed+=4;
 					if(true==REPEorNECheck(clocksPassed,inst.instPrefix,inst.addressSize))
 					{
 						EIPIncrement=0;
@@ -3078,7 +3079,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 				{
 					SubWordOrDword(inst.operandSize,data1,data2);
 					UpdateESIandEDIAfterStringOp(inst.addressSize,inst.operandSize);
-					clocksPassed+=8;
+					clocksPassed+=4;
 					if(true==REPEorNECheck(clocksPassed,inst.instPrefix,inst.addressSize))
 					{
 						EIPIncrement=0;
@@ -5862,6 +5863,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 	case I486_RENUMBER_MOVSB://            0xA4,
 		// REP/REPE/REPNE CX or ECX is chosen based on addressSize.
 		{
+			clocksPassed=7;
 			auto ECX=state.ECX();
 			auto prefix=REPNEtoREP(inst.instPrefix);
 			auto &seg=SegmentOverrideDefaultDS(inst.segOverride);
@@ -5872,7 +5874,6 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 			{
 				auto data=FetchByte(inst.addressSize,seg,state.ESI(),mem);
 				StoreByte(mem,inst.addressSize,state.ES(),state.EDI(),data);
-				clocksPassed+=7;
 				if(true!=state.exception)
 				{
 					UpdateSIorESIAfterStringOp(inst.addressSize,8);
@@ -5900,6 +5901,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 		break;
 	case I486_RENUMBER_MOVS://             0xA5,
 		{
+			clocksPassed=7;
 			auto ECX=state.ECX();
 			auto prefix=REPNEtoREP(inst.instPrefix);
 			auto &seg=SegmentOverrideDefaultDS(inst.segOverride);
@@ -5910,7 +5912,6 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 			{
 				auto data=FetchWordOrDword(inst.operandSize,inst.addressSize,seg,state.ESI(),mem);
 				StoreWordOrDword(mem,inst.operandSize,inst.addressSize,state.ES(),state.EDI(),data);
-				clocksPassed+=7;
 				if(true!=state.exception)
 				{
 					UpdateESIandEDIAfterStringOp(inst.addressSize,inst.operandSize);
@@ -7039,7 +7040,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 				auto AL=GetAL();
 				SubByte(AL,data);
 				UpdateDIorEDIAfterStringOp(inst.addressSize,8);
-				clocksPassed+=6;
+				clocksPassed+=2;
 				if(true==REPEorNECheck(clocksPassed,inst.instPrefix,inst.addressSize))
 				{
 					EIPIncrement=0;
@@ -7066,7 +7067,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 				auto EAX=GetEAX();
 				SubWordOrDword(inst.operandSize,EAX,data);
 				UpdateDIorEDIAfterStringOp(inst.addressSize,inst.operandSize);
-				clocksPassed+=6;
+				clocksPassed+=2;
 				if(true==REPEorNECheck(clocksPassed,inst.instPrefix,inst.addressSize))
 				{
 					EIPIncrement=0;
@@ -7350,7 +7351,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 			    ++ctr)
 			{
 				StoreByte(mem,inst.addressSize,state.ES(),state.EDI(),GetAL());
-				clocksPassed+=5;
+				clocksPassed+=1;
 				if(true!=state.exception)
 				{
 					UpdateDIorEDIAfterStringOp(inst.addressSize,8);
@@ -7386,7 +7387,7 @@ unsigned int i486DXFidelityLayer<FIDELITY>::RunOneInstruction(Memory &mem,InOut 
 			    ++ctr)
 			{
 				StoreWordOrDword(mem,inst.operandSize,inst.addressSize,state.ES(),state.EDI(),GetEAX());
-				clocksPassed+=5;
+				clocksPassed+=1;
 				if(true!=state.exception)
 				{
 					UpdateDIorEDIAfterStringOp(inst.addressSize,inst.operandSize);

--- a/src/towns/towns.h
+++ b/src/towns/towns.h
@@ -70,7 +70,7 @@ public:
 	enum
 	{
 		FREQUENCY_DEFAULT=25,                // MHz
-		FREQUENCY_SLOWMODE_DEFAULT=8,        // MHz
+		FREQUENCY_SLOWMODE_DEFAULT=5,        // MHz
 		FAST_DEVICE_POLLING_INTERVAL=10000,  // Nano-seconds
 		DEVICE_POLLING_INTERVAL=   8000000,  // 8ms
 
@@ -869,12 +869,12 @@ private:
 	}
 
 public:
-	i486DXCommon &CPU(void) override
+	i486DXCommon &CPU(void) override final
 	{
 		CheckBaseClassReady();
 		return _cpu;
 	}
-	const i486DXCommon &CPU(void) const override
+	const i486DXCommon &CPU(void) const override final
 	{
 		CheckBaseClassReady();
 		return _cpu;

--- a/src/vmbase/vmbase.h
+++ b/src/vmbase/vmbase.h
@@ -71,11 +71,12 @@ public:
 
 inline void VMBase::RunScheduledTasks(long long int vmTime)
 {
+	Device *devPtr=nullptr;
 	for(auto devIndex=allDevices[0]->vmNextTaskScheduledDeviceIndex;
 	    0<=devIndex;
-	    devIndex=allDevices[devIndex]->vmNextTaskScheduledDeviceIndex)
+	    devIndex=devPtr->vmNextTaskScheduledDeviceIndex)
 	{
-		auto devPtr=allDevices[devIndex];
+		devPtr=allDevices[devIndex];
 		if(devPtr->commonState.scheduleTime<=vmTime)
 		{
 			// Device may make another schedule in the call back.


### PR DESCRIPTION
pri timebalance(HOST CPU:Core i5 12600, in TMENU) value increased from 240000 to 290000 from previous version, and slow mode speed should also be close the first generation FM TOWNS(but not perfect. For example Lemmings need FREQ 8 more).

Reference REP instruction Clocks
https://www2.math.uni-wuppertal.de/~fpf/Uebungen/GdR-SS02/opcode_i.html