### PR TITLE
multi-bin bin/cue使用時のCD-DA再生を修正する

### DIFF
--- a/src/discimg/discimg.cpp
+++ b/src/discimg/discimg.cpp
@@ -439,7 +439,7 @@ unsigned int DiscImage::OpenCUEPostProcess(void)
 			tracks[i].start=HSGtoMSF(startSector+numPreGapSec);
 			tracks[i].end=HSGtoMSF(startSector+numSec-numPreGapSec-1);
 			tracks[i].locationInFile=locationInFile;
-			binaries[i].byteOffsetInDisc=locationInFile;
+			binaries[i].byteOffsetInDisc=locationInFile + binaries[i].bytesToSkip;
 			locationInFile+=numBytes;
 			startSector+=numSec;
 		}


### PR DESCRIPTION
b09cf55 このコミットでmulti-bin bin/cueのCD-DA再生がおかしくなっているようで、曲の頭の部分がスキップされてしまっています。

コード全体を見渡せていないので、修正方法や修正箇所がまずいようでしたら、指摘していただくか、山川機長の方で修正し直して下さい。

# 確認に使用したソフト
* 「スーパーストリートファイターII」の起動直後のオープニングデモのBGM
* 「雷電伝説」のゲーム開始時（ステージ1）のBGM
