### PR TITLE
Fix X11 window title displaying as "Main Window"

### DIFF
--- a/src/externals/connect_fssimplewindow/fssimplewindow_connection.cpp
+++ b/src/externals/connect_fssimplewindow/fssimplewindow_connection.cpp
@@ -32,6 +32,12 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 #include "ysgamepad.h"
 #include "townsparam.h"
 
+#ifndef TSUGARU_I486_HIGH_FIDELITY
+#define WINDOW_TITLE "FM Towns Emulator - TSUGARU"
+#else
+#define WINDOW_TITLE "FM Towns Emulator - TSUGARU (High-Fidelity Mode)"
+#endif
+
 
 FsSimpleWindowConnection::FsSimpleWindowConnection()
 {
@@ -1434,7 +1440,7 @@ void FsSimpleWindowConnection::WindowConnection::Start(void)
 
 	if(0==FsCheckWindowOpen())
 	{
-		FsOpenWindow(0,winY0,wid,hei+STATUS_HEI,1);
+		FsOpenWindow(0,winY0,wid,hei+STATUS_HEI,1,WINDOW_TITLE);
 	}
 	else
 	{
@@ -1464,11 +1470,6 @@ void FsSimpleWindowConnection::WindowConnection::Start(void)
 
 	winThr.winWid=640;
 	winThr.winHei=480;
-#ifndef TSUGARU_I486_HIGH_FIDELITY
-	FsSetWindowTitle("FM Towns Emulator - TSUGARU");
-#else
-	FsSetWindowTitle("FM Towns Emulator - TSUGARU (High-Fidelity Mode)");
-#endif
 
 	glClearColor(0,0,0,0);
 	mainTexId=GenTexture();

--- a/src/externals/fssimplewindow/src/glx/fsglxwrapper.cpp
+++ b/src/externals/fssimplewindow/src/glx/fsglxwrapper.cpp
@@ -205,7 +205,6 @@ void FsOpenWindow(const FsOpenWindowOption &opt)
 					XStoreName(ysXDsp,ysXWnd,title);
 
 
-// Should I use XSetWMProperties? titlebar problem.
 					XWMHints wmHints;
 					wmHints.flags=0;
 					wmHints.initial_state=NormalState;

--- a/src/externals/fssimplewindow/src/glx/fsglxwrapper.cpp
+++ b/src/externals/fssimplewindow/src/glx/fsglxwrapper.cpp
@@ -445,7 +445,14 @@ void FsGetWindowPosition(int &x0,int &y0)
 
 void FsSetWindowTitle(const char windowTitle[])
 {
-	printf("Sorry. %s not supported on this platform yet\n",__FUNCTION__);
+	const int formatSize = 8;
+	XChangeProperty(ysXDsp, ysXWnd,
+		XInternAtom(ysXDsp, "_NET_WM_NAME", False),
+		XInternAtom(ysXDsp, "UTF8_STRING", False),
+		formatSize,
+		PropModeReplace,
+		(unsigned char *) windowTitle,
+		strlen(windowTitle));
 }
 
 void FsPollDevice(void)


### PR DESCRIPTION
In X11, the title of the window was displayed as "Main Window".  With this change, the window title now displays as "FM Towns Emulator - TSUGARU".

Added capability in FsSetWindowTitle() to set the window title in X11.
Altered FsOpenWindow() call to ensure that the correct window title is shown at window creation.