### PR TITLE
Fixed build on Arch Linux.

### DIFF
--- a/src/device/device.h
+++ b/src/device/device.h
@@ -17,6 +17,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /* { */
 
 #include <vector>
+#include <cstdint>
 #include <string>
 
 

--- a/src/externals/d77/d77.h
+++ b/src/externals/d77/d77.h
@@ -113,6 +113,7 @@ Offset    Size          Meaning
 
 #include <array>
 #include <vector>
+#include <cstdint>
 #include <string>
 
 class D77File

--- a/src/osdependent/filesys/filesys.h
+++ b/src/osdependent/filesys/filesys.h
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <vector>
+#include <cstdint>
 #include <string>
 
 // When C++17's filesystem library is commonly available and stable, I'll change it to

--- a/src/rf5c68/rf5c68.h
+++ b/src/rf5c68/rf5c68.h
@@ -18,6 +18,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 #include <vector>
+#include <cstdint>
 #include <string>
 
 class RF5C68

--- a/src/ym2612/ym2612.h
+++ b/src/ym2612/ym2612.h
@@ -17,6 +17,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 /* { */
 
 #include <vector>
+#include <cstdint>
 #include <string>
 
 


### PR DESCRIPTION
When compiling from source on Arch Linux, I encountered the following error:
```
[  7%] Building CXX object osdependent/filesys/CMakeFiles/filesys.dir/filesys_common.cpp.o
In file included from /home/tim/code/TOWNSEMU/src/osdependent/filesys/filesys_common.cpp:2:
/home/tim/code/TOWNSEMU/src/osdependent/filesys/filesys.h:50:17: error: ‘uint16_t’ does not name a type
   50 |                 uint16_t FormatDOSTime(void) const;
      |                 ^~~~~~~~
/home/tim/code/TOWNSEMU/src/osdependent/filesys/filesys.h:9:1: note: ‘uint16_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    8 | #include <vector>
  +++ |+#include <cstdint>
    9 | #include <string>
```

Found that including cstdint in the changed header files resolved all errors relating to undefined uint16_t, uint32_t, uint64_t types and allowed the build to complete successfully.