### PR TITLE
Fix quotes for CFLAGS/CXXFLAGS settings

### DIFF
--- a/gui/src/CMakeLists.txt
+++ b/gui/src/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(UNIX)
-	set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -Wno-unused-variable)
-	set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -Wno-unused-variable)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
 endif()
 
 set(DISC_IMAGE_DIR "C:/D/TownsISO")


### PR DESCRIPTION
When you set CFLAGS or CXXFLAGS, build breaks because a ';' is introduced in resulting make.flags. Quoting as done in this PR avoids that.