### PR TITLE
Fixes for FreeBSD and Arch Linux compatibility

### DIFF
--- a/gui/src/CMakeLists.txt
+++ b/gui/src/CMakeLists.txt
@@ -8,8 +8,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if(UNIX)
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-incompatible-pointer-types")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
+
+	include_directories(/usr/local/include)
+	link_directories(/usr/local/lib)
 endif()
 
 set(DISC_IMAGE_DIR "C:/D/TownsISO")

--- a/src/externals/yssocket/src/yssocket.cpp
+++ b/src/externals/yssocket/src/yssocket.cpp
@@ -19,6 +19,7 @@ typedef int socklen_t;
 #else
 #include <unistd.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <strings.h>
 #include <arpa/inet.h>
 #include <sys/types.h>


### PR DESCRIPTION
Some small tweaks that, along with https://github.com/captainys/public/pull/11, allow Tsugaru to build on FreeBSD and Arch Linux. I tried to make these changes in a way that shouldn't disturb other platforms.

- Add /usr/local to include and lib search paths, where FreeBSD ports typically are installed.
- Add missing includes
- Add `-Wno-incompatible-pointer-types`, since Arch Linux gcc 15 appears to enable `-Werror=incompatible-pointer-types` by default