### PR TITLE
Fix FD settings not loading from profile

### DIFF
--- a/src/towns/townsparam/townsprofile.cpp
+++ b/src/towns/townsparam/townsprofile.cpp
@@ -393,7 +393,7 @@ bool TownsProfile::Deserialize(const std::vector <std::string> &text)
 			{
 				int drive=cpputil::Atoi(argv[1]);
 				int fileNum=cpputil::Atoi(argv[2]);
-				if(0<=drive && drive<NUM_FDDRIVES && 0<=fileNum && fileNum)
+				if(0<=drive && drive<NUM_FDDRIVES && 0<=fileNum && 0==fileNum)
 				{
 					fdImgFName[drive]=argv[3].c_str();
 				}


### PR DESCRIPTION
closes #173 

f9f8798161836dd45fc0ed5ccd69b4034406235f このコミットでうっかり削除してしまっているようだったので元に戻しました。
GitHub上で修正したので動作確認は出来ていません。
