### PR TITLE
yssocket: make Linux CheckReceive non-blocking to match Windows

### DIFF
--- a/src/externals/yssocket/src/yssocket.cpp
+++ b/src/externals/yssocket/src/yssocket.cpp
@@ -839,7 +839,11 @@ YSRESULT YsSocketClient::CheckReceive(void)
 	pfd.fd=internal->sock;
 	pfd.events=POLLIN;
 	pfd.revents=0;
-	if(poll(&pfd,1,1)>=1)
+	// Timeout must be 0 (non-blocking) to match the Windows select() path above
+	// (wait={0,0}).  A 1ms timeout here blocks the VM thread on every RxRDY poll
+	// when no data is pending, stalling emulation when the guest spins waiting
+	// for serial input (e.g. modem CONNECT / login response).
+	if(poll(&pfd,1,0)>=1)
 	{
 		ready=YSTRUE;
 	}


### PR DESCRIPTION
## Summary

`YsSocketClient::CheckReceive()` is called on the emulation thread every time the guest checks serial `RxRDY` ("is an inbound byte available?"). The two platform branches were meant to be equivalent non-blocking readiness checks, but they aren't:

- **Windows** uses `select()` with `timeval{0,0}` — zero timeout, returns immediately (the comment even says *"Don't wait. If no message, no need to read."*).
- **Linux** used `poll(&pfd, 1, 1)` — the `1` is a **1 ms timeout**, so with no data pending `poll()` blocks up to 1 ms before returning.

## Impact

Any guest that busy-polls the serial port waiting for inbound data — a Fujitsu Habitat modem client is one example — hits `CheckReceive()` against an empty socket on nearly every iteration. On Linux each check then sleeps up to 1 ms, and since the call runs on the emulation thread, that's dead time the virtual CPU isn't executing. In a tight wait loop that's easily hundreds-to-thousands of 1 ms sleeps per real second, so emulated time falls far behind wall-clock — showing up as general slowdown, audio underruns (the audio buffer drains during the sleeps), and apparent freezes during the busiest serial waits.

## Fix

Set the Linux `poll()` timeout to `0` so the readiness check is non-blocking, matching Windows.

## Notes

`YsSocketClient::Send()` on Linux uses the same `poll(..., 1)` shape, but it's gated by `TxRDY` and a connected socket is virtually always writable, so it returns immediately in practice — left unchanged here, but worth aligning for consistency if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
